### PR TITLE
Simple spelling mistake fix

### DIFF
--- a/views/publish.pug
+++ b/views/publish.pug
@@ -17,7 +17,7 @@ block content
         input#submit.threads-button(type='submit' value='Publish' disabled='disabled')
 
     template#template-status-FINISHED
-        p All set! Your can publish your thread now. 🧵
+        p All set! You can publish your thread now. 🧵
     template#template-status-IN_PROGRESS
         p Your content is still processing. The status will be refreshed automatically. ⏳
     template#template-status-ERROR


### PR DESCRIPTION
Fixed a spelling mistake on line 20 inside `views -> publish.pug` , containing a spelling mistake that I found while testing the API.