### PR TITLE
Alt Text

### DIFF
--- a/views/thread.pug
+++ b/views/thread.pug
@@ -21,6 +21,9 @@ block content
                 td
                     a(href=media_url target='_blank') #{media_url}
             tr
+                td Alt Text
+                td #{alt_text}
+            tr
                 td Permalink
                 td
                     a(href=permalink target='_blank') #{permalink}

--- a/views/upload.pug
+++ b/views/upload.pug
@@ -20,6 +20,14 @@ block content
             justify-content: center;
             margin-bottom: 12px;
         }
+        div.attachment-item-details {
+            display: flex;
+            flex-direction: column;
+        }
+        div.attachment-item-type-and-url {
+            display: flex;
+            flex-direction: row;
+        }
         textarea::placeholder {
             text-align: center;
             line-height: 15px;
@@ -61,14 +69,20 @@ block content
 
     script#attachment-template(type='text/template')
         div.attachment-item
-            label(for='attachmentType')
-            | Type &nbsp;&nbsp;
-            select(name='attachmentType[]')
-                option(value='Image') Image
-                option(value='Video') Video
-            label(for='attachmentUrl')
-            | URL &nbsp;&nbsp;
-            input(type='text' name='attachmentUrl[]' autocomplete='off')
+            div.attachment-item-details
+                div.attachment-item-type-and-url
+                    label(for='attachmentType')
+                    | Type &nbsp;&nbsp;
+                    select(name='attachmentType[]')
+                        option(value='Image') Image
+                        option(value='Video') Video
+                    label(for='attachmentUrl')
+                    | URL &nbsp;&nbsp;
+                    input(type='text' name='attachmentUrl[]' autocomplete='off')
+                div.attachment-item-alt-text
+                    label(for='attachmentAltText')
+                    |   Alt Text &nbsp;&nbsp;
+                    input(type='text' name='attachmentAltText[]' value='')
 
             // The parent of this node will be removed from the DOM
             span.delete ❌


### PR DESCRIPTION
Added `alt_text` field for the publishing and retrieval flows:
<img width="716" alt="image" src="https://github.com/user-attachments/assets/64377cb7-7812-41e5-a40d-4673d45d8694">
<img width="664" alt="image" src="https://github.com/user-attachments/assets/6fb577f1-9ab4-4a59-8faf-b645549582b5">
