### PR TITLE
Support poll attachments

### DIFF
--- a/public/scripts/form.js
+++ b/public/scripts/form.js
@@ -23,6 +23,59 @@ function onAsyncRequestEnded() {
     }
 }
 
+function isPollInputValid(data) {
+    const pollOptionA = data.get('pollOptionA');
+    const pollOptionB = data.get('pollOptionB');
+    const pollOptionC = data.get('pollOptionC');
+    const pollOptionD = data.get('pollOptionD');
+    const pollAttached = pollOptionA || pollOptionB || pollOptionC || pollOptionD;
+
+    if (pollAttached && (!pollOptionA || !pollOptionB)) {
+        alert('Options A and B are required for polls.');
+        return false;
+    }
+
+    if (pollOptionD && !pollOptionC) {
+        alert('Option D cannot be used without option C.');
+        return false;
+    }
+
+    return true;
+}
+
+function isAttachmentsInputValid(data) {
+    const pollAttached =
+        data.get('pollOptionA') ||
+        data.get('pollOptionB') ||
+        data.get('pollOptionC') ||
+        data.get('pollOptionD');
+    const linkAttached = data.get('linkAttachment');
+    const hasMediaAttachment = data.has('attachmentType[]');
+
+    if (pollAttached && linkAttached) {
+        alert('Link attachments and poll attachments cannot be used together.');
+        return false;
+    }
+
+    if (hasMediaAttachment && linkAttached) {
+        alert('Link attachments can only be used with text posts.')
+    }
+
+    if (hasMediaAttachment && pollAttached) {
+        alert('Poll attachments can only be used with text posts.')
+    }
+
+    return true;
+}
+
+function isFormDataValid(data) {
+    if (!isPollInputValid(data) || !isAttachmentsInputValid(data)) {
+        return false;
+    }
+
+    return true;
+}
+
 async function processFormAsync(urlGenerator) {
     const form = document.getElementById('form');
     form.addEventListener('submit', async (e) => {
@@ -30,6 +83,10 @@ async function processFormAsync(urlGenerator) {
 
         const button = document.getElementById('submit');
         const formData = new FormData(e.target, button);
+
+        if (!isFormDataValid(formData)) {
+            return;
+        }
 
         onAsyncRequestStarting();
 

--- a/public/scripts/upload.js
+++ b/public/scripts/upload.js
@@ -57,4 +57,17 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     await updateMediaType(0, null);
+
+    const attachPollButton = document.getElementById('poll-attachment-button');
+    attachPollButton.addEventListener('click', async (e) => {
+        e.preventDefault();
+
+        const pollAttachmentOptions = document.getElementById('poll-attachment-options');
+        if (pollAttachmentOptions.style.display === 'none') {
+            pollAttachmentOptions.style.display = 'block';
+        } else {
+            pollAttachmentOptions.style.display = 'none';
+        }
+
+    });
 });

--- a/views/thread.pug
+++ b/views/thread.pug
@@ -27,6 +27,23 @@ block content
                 td Link Attachment URL
                 td #{link_attachment_url}
             tr
+                td Poll
+                td
+                    if option_a && option_b
+                        table
+                            tr
+                                td Option A
+                                td #{option_a}
+                            tr
+                                td Option B
+                                td #{option_b}
+                            tr
+                                td Option C
+                                td #{option_c}
+                            tr
+                                td Option D
+                                td #{option_d}
+            tr
                 td Permalink
                 td
                     a(href=permalink target='_blank') #{permalink}

--- a/views/upload.pug
+++ b/views/upload.pug
@@ -75,6 +75,28 @@ block content
         |   Link Attachment
         input#link-attachment(type='text' name='linkAttachment' value='')
 
+        button#poll-attachment-button(type='button' name='pollAttachment') Attach Poll 🗳️
+        div#poll-attachment-options(style='display:none')
+            div.poll-attachment-option
+                label(for='pollOptionA')
+                | Option A &nbsp;&nbsp;
+                input(type='text' name='pollOptionA' autocomplete='off')
+
+            div.poll-attachment-option
+                label(for='pollOptionB')
+                | Option B &nbsp;&nbsp;
+                input(type='text' name='pollOptionB' autocomplete='off')
+
+            div.poll-attachment-option
+                label(for='pollOptionC')
+                | Option C &nbsp;&nbsp;
+                input(type='text' name='pollOptionC' autocomplete='off')
+
+            div.poll-attachment-option
+                label(for='pollOptionD')
+                | Option D &nbsp;&nbsp;
+                input(type='text' name='pollOptionD' autocomplete='off')
+
         if quotePostId
             a(href=`/threads/${quotePostId}`) Quoting #{quotePostId}
             input#quote-post-id(type='hidden' name='quotePostId' value=quotePostId)


### PR DESCRIPTION
# Changes
- Added support for creating posts with poll attachments
- Added polls to the single post view
- Added input validation for post attachments

# Screenshots
## Post with poll
<img width="2027" alt="Screenshot 2025-05-09 at 12 11 01 PM" src="https://github.com/user-attachments/assets/7096f6f3-da62-487c-b598-4a6a9f4619b8" />

## Post without poll
<img width="2027" alt="Screenshot 2025-05-09 at 12 11 23 PM" src="https://github.com/user-attachments/assets/db8e94ac-30f6-40ee-b80d-398d73cf8dfa" />

## Attaching poll
<img width="748" alt="Screenshot 2025-05-09 at 12 59 16 PM" src="https://github.com/user-attachments/assets/0ee4cd11-afaf-4f25-8363-fdc2408e5586" />
<img width="748" alt="Screenshot 2025-05-09 at 12 59 22 PM" src="https://github.com/user-attachments/assets/306f3942-0e52-4240-8904-2ca5d2686819" />
