### PR TITLE
Retrieve GIF URL for Individual Post

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ const FIELD__LIKES = 'likes';
 const FIELD__LINK_ATTACHMENT_URL = 'link_attachment_url';
 const FIELD__MEDIA_TYPE = 'media_type';
 const FIELD__MEDIA_URL = 'media_url';
+const FIELD__GIF_URL = 'gif_url';
 const FIELD__PERMALINK = 'permalink';
 const FIELD__POLL_ATTACHMENT = 'poll_attachment';
 const FIELD__REPLIES = 'replies';
@@ -492,6 +493,7 @@ app.get('/threads/:threadId', loggedInUserChecker, async (req, res) => {
             FIELD__TEXT,
             FIELD__MEDIA_TYPE,
             FIELD__MEDIA_URL,
+            FIELD__GIF_URL,
             FIELD__PERMALINK,
             FIELD__TIMESTAMP,
             FIELD__IS_REPLY,

--- a/views/thread.pug
+++ b/views/thread.pug
@@ -21,6 +21,10 @@ block content
                 td
                     a(href=media_url target='_blank') #{media_url}
             tr
+                td GIF URL
+                td
+                    a(href=gif_url target='_blank') #{gif_url}
+            tr
                 td Alt Text
                 td #{alt_text}
             tr


### PR DESCRIPTION
If a post has a GIF attachment, we should display it.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/f81604b9-3e2b-4349-9269-e205626d5a26" />