### PR TITLE
Upgrade Multer to 2.0.1 to Address Security Vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express": "^4.17.3",
     "express-session": "^1.17.2",
     "luxon": "^3.7.1",
-    "multer": "^1.4.5-lts.1",
+    "multer": "^2.0.1",
     "pug": "^3.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
```
npm install multer@2.0.1 --save
```

This should address the following security vulnerabilities:
https://github.com/fbsamples/threads_api/security/dependabot/1
https://github.com/fbsamples/threads_api/security/dependabot/2
https://github.com/fbsamples/threads_api/security/dependabot/3
https://github.com/fbsamples/threads_api/security/dependabot/4

I confirmed that publishing with the sample app still works after upgrading multer from 1.4.5-lts.1 to 2.0.1.