### PR TITLE
feat: Add support for spoilers

### DIFF
--- a/public/scripts/text-parser.js
+++ b/public/scripts/text-parser.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Export for use in other files
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { extractSpoilerInfo };
+}
+
+/**
+ * Extracts spoiler text and their positions from a string with **spoiler** markers
+ * @param {string} text - Input text with **spoiler** markers
+ * @returns {Object} - Object containing spoiler info and cleaned text
+ */
+function extractSpoilerInfo(text) {
+    const spoilerMarker = '**spoiler**';
+    const textEntities = [];
+    let cleanedText = '';
+    let currentPosition = 0;
+    let searchPosition = 0;
+
+    while (searchPosition < text.length) {
+        // Find the next spoiler start marker
+        const startMarkerIndex = text.indexOf(spoilerMarker, searchPosition);
+
+        if (startMarkerIndex === -1) {
+            // No more spoiler markers, add remaining text
+            cleanedText += text.substring(searchPosition);
+            break;
+        }
+
+        // Add text before the spoiler marker to cleaned text
+        const textBeforeMarker = text.substring(searchPosition, startMarkerIndex);
+        cleanedText += textBeforeMarker;
+        currentPosition += textBeforeMarker.length;
+
+        // Find the closing spoiler marker
+        const contentStartIndex = startMarkerIndex + spoilerMarker.length;
+        const endMarkerIndex = text.indexOf(spoilerMarker, contentStartIndex);
+
+        if (endMarkerIndex === -1) {
+            // No closing marker found, treat remaining text as normal
+            cleanedText += text.substring(startMarkerIndex);
+            break;
+        }
+
+        // Extract spoiler content
+        const spoilerContent = text.substring(contentStartIndex, endMarkerIndex);
+
+        // Record spoiler info
+        textEntities.push({
+            entity_type: "SPOILER",
+            text: spoilerContent,
+            offset: currentPosition.toString(),
+            length: spoilerContent.length.toString(),
+        });
+
+        // Add spoiler content to cleaned text
+        cleanedText += spoilerContent;
+        currentPosition += spoilerContent.length;
+
+        // Move search position past the end marker
+        searchPosition = endMarkerIndex + spoilerMarker.length;
+    }
+
+    return {
+        textEntities: textEntities,
+        text: cleanedText
+    };
+}

--- a/public/scripts/text-parser.js
+++ b/public/scripts/text-parser.js
@@ -22,7 +22,7 @@ function extractSpoilerInfo(text) {
     let currentPosition = 0;
     let searchPosition = 0;
 
-    while (searchPosition < text.length) {
+    while (currentPosition < text.length && searchPosition < text.length) {
         // Find the next spoiler start marker
         const startMarkerIndex = text.indexOf(spoilerMarker, searchPosition);
 

--- a/public/scripts/upload.js
+++ b/public/scripts/upload.js
@@ -7,17 +7,21 @@
 
 async function updateMediaType(attachmentsCount, attachmentListElem) {
     const mediaTypeElem = document.getElementById('media-type');
+    const spoilerMediaControl = document.querySelector('.spoiler-media-control');
 
     let mediaTypeDesc;
     if (attachmentsCount === 0) {
         mediaTypeDesc = 'Text 📝';
+        spoilerMediaControl.style.display = 'none';
     } else if (attachmentsCount === 1) {
         const singleAttachmentType =
             attachmentListElem.querySelector('select').value;
         if (singleAttachmentType === 'Image') mediaTypeDesc = 'Image 🖼️';
         else mediaTypeDesc = 'Video 🎬';
+        spoilerMediaControl.style.display = 'block';
     } else {
         mediaTypeDesc = 'Carousel 🎠';
+        spoilerMediaControl.style.display = 'block';
     }
 
     mediaTypeElem.innerText = mediaTypeDesc;

--- a/views/thread.pug
+++ b/views/thread.pug
@@ -24,6 +24,9 @@ block content
                 td Text
                 td #{text}
             tr
+                td Text Entities
+                td #{text_entities}
+            tr
                 td Topic Tag
                 td #{topic_tag}
             tr
@@ -33,6 +36,9 @@ block content
                 td Media URL
                 td
                     a(href=media_url target='_blank') #{media_url}
+            tr
+                td Is Spoiler Media Post
+                td #{is_spoiler_media}
             tr
                 td GIF URL
                 td

--- a/views/upload.pug
+++ b/views/upload.pug
@@ -35,6 +35,8 @@ block content
         textarea {
             text-align: center;
             padding: 5px 0;
+            border-radius: 20px;
+            height: 100px;
         }
         img {
             margin-bottom: 15px;
@@ -53,6 +55,9 @@ block content
         #quote-post-id {
             width: 200px;
         }
+        .spoiler-media-control {
+            display: none;
+        }
 
     if (replyToId !== undefined)
         p(style='color: gray') Replying to #{replyToId}
@@ -67,6 +72,11 @@ block content
             img#attachments-button(src='/img/attachment.png')
             div.attachment-controls
                 div#attachments-list.attachments
+        div.spoiler-media-control
+            label(for='spoilerMedia')
+            |   Mark Media as Spoiler &nbsp;&nbsp;
+            input(type='checkbox' name='spoilerMedia' value='true')
+        br
 
         label(for="reply-control") Who Can Reply
         select#reply-control(name='replyControl' hint="Reply Control")


### PR DESCRIPTION
Add support for publishing post with spoilers. Spoilers can be added in text, image, video and carousel posts.

**Passing spoilers in Text Post:**

https://github.com/user-attachments/assets/83c64d38-cd9d-4cf6-9fcb-6a4957562acd

**Passing spoilers in Image Post. Same can be used for videos, carousel posts:**

https://github.com/user-attachments/assets/ff674236-cec7-4297-a756-b4f28184a28d

