### PR TITLE
Remove text field from text_entities

### DIFF
--- a/public/scripts/text-parser.js
+++ b/public/scripts/text-parser.js
@@ -53,7 +53,6 @@ function extractSpoilerInfo(text) {
         // Record spoiler info
         textEntities.push({
             entity_type: "SPOILER",
-            text: spoilerContent,
             offset: currentPosition.toString(),
             length: spoilerContent.length.toString(),
         });


### PR DESCRIPTION
Text field in not required to be set in text_entities for spoilers.


https://github.com/user-attachments/assets/26965b5a-20dc-491f-a3ee-f87d31cb671f

