### PR TITLE
Remove Access Token from oEmbed API

### DIFF
--- a/postman/threads-api.postman_collection.json
+++ b/postman/threads-api.postman_collection.json
@@ -3343,18 +3343,6 @@
 									"key": "url",
 									"value": "https://www.threads.net/@threads/post/DCkkKl_OGb1",
 									"description": "This is the URL of the Threads post to be embedded. With standard access, you may embed posts from the @meta, @threads, @instagram, and @facebook accounts."
-								},
-								{
-									"key": "access_token",
-									"value": "TH|{{app_id}}|{{app_secret}}",
-									"description": "This is your app access token. This consists of your app's ID and secret.",
-									"disabled": true
-								},
-								{
-									"key": "access_token",
-									"value": "{{app_access_token}}",
-									"description": "This is your app access token received via the GET /oauth/access_token endpoint. See the Authorization folder for details.",
-									"disabled": true
 								}
 							]
 						}
@@ -3378,18 +3366,6 @@
 											"key": "url",
 											"value": "https://www.threads.net/@threads/post/DCkkKl_OGb1",
 											"description": "This is the URL of the Threads post to be embedded. With standard access, you may embed posts from the @meta, @threads, @instagram, and @facebook accounts."
-										},
-										{
-											"key": "access_token",
-											"value": "TH|{{app_id}}|{{app_secret}}",
-											"description": "This is your app access token. This consists of your app's ID and secret.",
-											"disabled": true
-										},
-										{
-											"key": "access_token",
-											"value": "{{app_access_token}}",
-											"description": "This is your app access token received via the GET /oauth/access_token endpoint. See the Authorization folder for details.",
-											"disabled": true
 										}
 									]
 								}

--- a/src/index.js
+++ b/src/index.js
@@ -1117,8 +1117,7 @@ app.get('/oEmbed', async (req, res) => {
         `oembed`,
         {
             url,
-        },
-        `TH|${APP_ID}|${API_SECRET}`
+        }
     );
 
     let html = '<p>Unable to embed</p>';

--- a/src/index.js
+++ b/src/index.js
@@ -122,9 +122,9 @@ const agent = new https.Agent({
 });
 
 const GRAPH_API_BASE_URL =
-    'https://graph.threads.net/' +
+    'https://graph.threads.com/' +
     (GRAPH_API_VERSION ? GRAPH_API_VERSION + '/' : '');
-const AUTHORIZATION_BASE_URL = 'https://www.threads.net';
+const AUTHORIZATION_BASE_URL = 'https://www.threads.com';
 
 let initial_access_token = INITIAL_ACCESS_TOKEN;
 let initial_user_id = INITIAL_USER_ID;


### PR DESCRIPTION
According to https://developers.facebook.com/docs/threads/changelog#march-3--2026, the Threads oEmbed API no longer requires an access token. Therefore, we can remove it when building the Graph API request URL.

We can also safely update the sample app to use "graph.threads.com" for all API calls.

https://threads-sample.meta:8000/oEmbed?url=https%3A%2F%2Fwww.threads.com%2F%40mountaindew%2Fpost%2FDWOrEeiDvH1

<img width="712" height="569" alt="image" src="https://github.com/user-attachments/assets/8a752961-c1a6-4480-9e1d-cd6bbdfa208c" />